### PR TITLE
date parsing is broken on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+node_modules
+.DS_Store

--- a/lib/x509.js
+++ b/lib/x509.js
@@ -1,0 +1,23 @@
+var x509Native = require("../build/Release/x509");
+var x509 = module.exports;
+var moment = require('moment');
+
+x509.getAltNames = function(cert) {
+  return x509Native.getAltNames(cert);
+};
+
+x509.getIssuer = function(cert) {
+  return x509Native.getIssuer(cert);
+};
+
+x509.getSubject = function(cert) {
+  return x509Native.getSubject(cert);
+};
+
+x509.parseCert = function(cert) {
+  var parsed = x509Native.parseCert(cert);
+  // convert notBefore and not After
+  parsed.notBefore = moment.utc(parsed.notBefore, 'YYMMDDhhmmss').toDate();
+  parsed.notAfter = moment.utc(parsed.notAfter, 'YYMMDDhhmmss').toDate();
+  return parsed;
+};

--- a/package.json
+++ b/package.json
@@ -3,13 +3,17 @@
   "version": "0.0.1",
   "description": "Simple X509 certificate parser.",
   "author": "Colton Baker",
-  "main": "./build/Release/x509",
+  "main": "./lib/x509",
   "repository": {
     "type": "git",
     "url": "http://github.com/Southern/node-x509"
   },
   "scripts": {
+    "test": "node test/test",
     "preinstall": "make"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "moment": "~2.1.0"
+  }
 }

--- a/src/x509.cc
+++ b/src/x509.cc
@@ -115,47 +115,7 @@ Handle<Object> parse_cert(const Arguments &args) {
 
 Handle<String> parse_date(char *date) {
   HandleScope scope;
-  char current[5];
-  char *theDate = (char*) malloc(sizeof(char) * 30);
-  X509_DATE *xdate = (X509_DATE*) malloc(sizeof(X509_DATE));
-  int i;
-
-  for (i = 0; i < (int) strlen(date) - 1; i += 2) {
-    strncpy(current, &date[i], 2);
-
-    switch (i) {
-      case 0:
-        sprintf(xdate->year, "%s", current);
-        break;
-
-      case 2:
-        sprintf(xdate->month, "%s", current);
-        break;
-
-      case 4:
-        sprintf(xdate->day, "%s", current);
-        break;
-
-      case 6:
-        sprintf(xdate->hours, "%s", current);
-        break;
-
-      case 8:
-        sprintf(xdate->minutes, "%s", current);
-        break;
-
-      case 10:
-        sprintf(xdate->seconds, "%s", current);
-        break;
-    }
-  }
-
-  sprintf(theDate, "%s/%s/20%s %s:%s:%s GMT", xdate->month, xdate->day, xdate->year, xdate->hours, xdate->minutes, xdate->seconds);
-
-  free(xdate);
-  free(theDate);
-
-  return scope.Close(String::New(theDate));
+  return scope.Close(String::New(date));
 }
 
 Handle<Object> parse_name(X509_NAME *subject) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-var x509 = require('../build/Release/x509'),
+var x509 = require('../lib/x509'),
     fs = require('fs'),
     path = require('path');
 


### PR DESCRIPTION
This patch creates a thin wrapper in js and will do the parsing there instead.
