### PR TITLE
Fix for parsing a certificate with an extension attribute with a NULL-value

### DIFF
--- a/src/x509.cc
+++ b/src/x509.cc
@@ -280,13 +280,13 @@ Local<Value> try_parse(const std::string& dataString) {
     char *data = (char*) malloc(bptr->length + 1);
 
     if (bptr->data == NULL){
-	BIO_free(ext_bio);
-	data="";
+      BIO_free(ext_bio);
+      data="";
     } else {
-	    BUF_strlcpy(data, bptr->data, bptr->length );
-	    data = trim(data, bptr->length);
-	    BIO_free(ext_bio);
-   }
+      BUF_strlcpy(data, bptr->data, bptr->length );
+      data = trim(data, bptr->length);
+      BIO_free(ext_bio);
+    }
 
     unsigned nid = OBJ_obj2nid(obj);
     if (nid == NID_undef) {

--- a/src/x509.cc
+++ b/src/x509.cc
@@ -277,12 +277,16 @@ Local<Value> try_parse(const std::string& dataString) {
     BUF_MEM *bptr;
     BIO_get_mem_ptr(ext_bio, &bptr);
     BIO_set_close(ext_bio, BIO_CLOSE);
-
     char *data = (char*) malloc(bptr->length + 1);
-    BUF_strlcpy(data, bptr->data, bptr->length + 1);
-    data = trim(data, bptr->length);
 
-    BIO_free(ext_bio);
+    if (bptr->data == NULL){
+	BIO_free(ext_bio);
+	data="";
+    } else {
+	    BUF_strlcpy(data, bptr->data, bptr->length );
+	    data = trim(data, bptr->length);
+	    BIO_free(ext_bio);
+   }
 
     unsigned nid = OBJ_obj2nid(obj);
     if (nid == NID_undef) {


### PR DESCRIPTION
This pull request should resove #37 by checking if a extension contains NULL data. When implemented, the extension is still given as output, but with an empty value (\0).