### PR TITLE
Fix build warnings in node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "nan": "2.2.0"
+    "nan": "2.6.2"
   }
 }

--- a/src/x509.cc
+++ b/src/x509.cc
@@ -445,7 +445,8 @@ Local<Value> parse_date(ASN1_TIME *date) {
   Local<Object> global = Nan::GetCurrentContext()->Global();
   Local<Object> DateObject = Nan::Get(global,
     Nan::New<String>("Date").ToLocalChecked()).ToLocalChecked()->ToObject();
-  return scope.Escape(DateObject->CallAsConstructor(1, args));
+  Nan::MaybeLocal<Value> parsedDate = Nan::CallAsConstructor(DateObject, 1, args);
+  return scope.Escape(parsedDate.ToLocalChecked());
 }
 
 Local<Object> parse_name(X509_NAME *subject) {


### PR DESCRIPTION
* Update Nan version in package.json to 2.6.2

* Use Nan::CallAsConstructor instead of v8::Object::CallAsConstructor

https://github.com/Southern/node-x509/issues/53
